### PR TITLE
Fix ParameterExtent test

### DIFF
--- a/tests/src/python/plugins/processing/ParametersTest.py
+++ b/tests/src/python/plugins/processing/ParametersTest.py
@@ -61,10 +61,15 @@ class ParametersTest(unittest.TestCase):
         assert not param.setValue('0,2,0')
         assert not param.setValue('0,2,0,a')
         assert param.setValue('0,2,2,4')
-        assert param.value == '0,2,2,4'
+        self.assertEqual(param.value, '0,2,2,4')
         assert param.setValue(None)
-        assert param.value == param.default, 'Result: {}, Expected: {}'.format(param.value, param.default)
+        self.assertEqual(param.value, None)
 
+        required = ParameterExtent('name', 'desc', optional=False)
+        first_value = '0,2,2,4'
+        assert required.setValue(first_value)
+        assert not required.setValue(None)
+        self.assertEqual(required.value, first_value)
 
 def suite():
     suite = unittest.makeSuite(ParametersTest, 'test')


### PR DESCRIPTION
Test was asserting that you could not set parameter to None, even though it was an "optional" parameter. 

There was some interesting behavior related to default values in the broken test, so I've preserved that coverage in some new testing.

Note that to get this to run, I had to make some pretty broad changes to imports and PYTHONPATH.

It is mighty satisfying to see tests run without compiling... so fast!

```
./test-runner tests/src/python/plugins/processing/ParametersTest.py
...
----------------------------------------------------------------------
Ran 3 tests in 0.000s

OK
```