### PR TITLE
Revert "Preserve visibility of relation editor edit state buttons"

### DIFF
--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -35,7 +35,6 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget* parent )
     , mViewMode( QgsDualView::AttributeEditor )
     , mShowLabel( true )
     , mVisible( false )
-    , mInitialized( false )
 {
   QVBoxLayout* topLayout = new QVBoxLayout( this );
   topLayout->setContentsMargins( 0, 9, 0, 0 );
@@ -181,7 +180,6 @@ void QgsRelationEditorWidget::setRelationFeature( const QgsRelation& relation, c
     QgsFeatureRequest myRequest = mRelation.getRelatedFeaturesRequest( mFeature );
 
     mDualView->init( mRelation.referencingLayer(), nullptr, myRequest, mEditorContext );
-    mInitialized = true;
   }
 }
 
@@ -523,7 +521,7 @@ void QgsRelationEditorWidget::updateUi()
   // If it is already initialized, it has been set visible before and the currently shown feature is changing
   // and the widget needs updating
 
-  if ( mVisible && !mInitialized )
+  if ( mVisible )
   {
     QgsFeatureRequest myRequest = mRelation.getRelatedFeaturesRequest( mFeature );
 
@@ -551,7 +549,6 @@ void QgsRelationEditorWidget::updateUi()
     {
       mDualView->init( mRelation.referencingLayer(), nullptr, myRequest, mEditorContext );
     }
-    mInitialized = true;
   }
 
   mToggleEditingButton->setVisible( true );

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -151,7 +151,6 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
 
     bool mShowLabel;
     bool mVisible;
-    bool mInitialized;
 };
 
 #endif // QGSRELATIONEDITOR_H


### PR DESCRIPTION
This reverts commit 523cd074c8ef4df69f9f1d56ffbd8d0428410181.

## Description
Include a few sentences describing the overall goals for this PR (pull request). If applicable also add screenshots.

## Checklist

> Reviewing is a process done by project maintainers, mostly on a volunteer basis. We try to keep the overhead as small as possible and appreciate if you help us to do so by completing the following items. Feel free to ask in a comment if you have troubles with any of them.

- [ ] Commit messages are descriptive and explain the rationale for changes
- [ ] Commits which fix bugs include `fixes #11111` in the commit message next to the description
- [ ] Commits which add new features are tagged with `[FEATURE]` in the commit message
- [ ] Commits which change the UI or existing user workflows are tagged with `[needs-docs]` in the commit message and containt sufficient information in the commit message to be documented
- [ ] I have read the [QGIS Coding Standards](https://docs.qgis.org/testing/en/docs/developers_guide/codingstandards.html) and this PR complies with them
- [ ] This PR passes all existing unit tests (test results will be reported by travis-ci after opening this PR)
- [ ] New unit tests have been added for core changes
- [ ] I have run [the `scripts/prepare-commit.sh` script](https://github.com/qgis/QGIS/blob/master/.github/CONTRIBUTE.md#contributing-to-qgis) before each commit
